### PR TITLE
fix Relative path cannot be resolved.

### DIFF
--- a/pkg/model/url.go
+++ b/pkg/model/url.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"golang.org/x/net/publicsuffix"
-
-	"github.com/Qianlitp/crawlergo/pkg/tools/requests"
 )
 
 type URL struct {
@@ -19,6 +17,7 @@ type URL struct {
 
 func GetUrl(_url string, parentUrls ...URL) (*URL, error) {
 	// 补充解析URL为完整格式
+	logger.Debug("url %s", _url)
 	var u URL
 	_url, err := u.parse(_url, parentUrls...)
 	if err != nil {
@@ -26,7 +25,8 @@ func GetUrl(_url string, parentUrls ...URL) (*URL, error) {
 	}
 
 	if len(parentUrls) == 0 {
-		_u, err := requests.UrlParse(_url)
+		_u, err := UrlParse(_url)
+
 		if err != nil {
 			return nil, err
 		}
@@ -36,6 +36,13 @@ func GetUrl(_url string, parentUrls ...URL) (*URL, error) {
 		}
 	} else {
 		pUrl := parentUrls[0]
+		//判断是路径
+		if strings.HasPrefix(_url, "/") {
+			//去掉\r \n \s
+			r := regexp.MustCompile(`(\r|\n|\s+)`)
+			_url = r.ReplaceAllString(_url, "")
+			pUrl.Path = _url
+		}
 		_u, err := pUrl.Parse(_url)
 		if err != nil {
 			return nil, err

--- a/pkg/model/url.go
+++ b/pkg/model/url.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"golang.org/x/net/publicsuffix"
+
+	"github.com/Qianlitp/crawlergo/pkg/tools/requests"
 )
 
 type URL struct {
@@ -17,7 +19,6 @@ type URL struct {
 
 func GetUrl(_url string, parentUrls ...URL) (*URL, error) {
 	// 补充解析URL为完整格式
-	logger.Debug("url %s", _url)
 	var u URL
 	_url, err := u.parse(_url, parentUrls...)
 	if err != nil {
@@ -25,7 +26,7 @@ func GetUrl(_url string, parentUrls ...URL) (*URL, error) {
 	}
 
 	if len(parentUrls) == 0 {
-		_u, err := UrlParse(_url)
+		_u, err := requests.UrlParse(_url)
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
爬取网站的时候有一些路径比如 `<a  href=/cn/abbout  ....>`,这种相对路径的链接会在函数model.GetUrl解析失败照成漏抓，影响还是挺大的 ,和awvs对比的话。但这个可能需要更多的测试。