### PR TITLE
Added docker usage. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ bin/crawlergo -c /tmp/chromium/chrome -t 10 http://testphp.vulnweb.com/
 ```
 
 
+### Docker usage
+
+You can also use this with docker without headache: 
+
+```shell
+git clone https://github.com/Qianlitp/crawlergo
+docker build . -t crawlergo
+docker run crawlergo http://testphp.vulnweb.com/
+```
+
+
 ### Using Proxy
 
 ```shell

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,26 @@
+## Build
+FROM golang:1.16-buster AS build
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install unzip && rm -rf /var/lib/apt/lists/*
+COPY ./ ./
+RUN make build
+RUN chmod +x ./get_chrome.sh && ./get_chrome.sh
+
+
+## Deploy
+FROM ubuntu:18.04
+
+WORKDIR /
+
+COPY --from=build /app/bin/crawlergo /crawlergo
+COPY --from=build /app/latest/ /chrome/
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+     libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+     libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libgbm1 \
+     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 libnss3 \
+     && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/crawlergo", "-c", "/chrome/chrome"]

--- a/get_chrome.sh
+++ b/get_chrome.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+cd $(dirname $0)
+
+LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media"
+
+REVISION=$(curl -s -S $LASTCHANGE_URL)
+
+echo "latest revision is $REVISION"
+
+if [ -d $REVISION ] ; then
+  echo "already have latest version"
+  exit
+fi
+
+ZIP_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F$REVISION%2Fchrome-linux.zip?alt=media"
+
+ZIP_FILE="${REVISION}-chrome-linux.zip"
+
+echo "fetching $ZIP_URL"
+
+rm -rf $REVISION
+mkdir $REVISION
+pushd $REVISION
+curl -# $ZIP_URL > $ZIP_FILE
+echo "unzipping.."
+unzip $ZIP_FILE
+popd
+rm -f ./latest
+ln -s $REVISION/chrome-linux/ ./latest


### PR DESCRIPTION
Chrome will automatically install into container with crawlergo.
So you can use it just like this:

```shell
git clone https://github.com/Qianlitp/crawlergo
docker build . -t crawlergo
docker run crawlergo http://testphp.vulnweb.com/
````