### PR TITLE
add: 增加爬虫整体运行 最大超时时间

### DIFF
--- a/cmd/crawlergo/flag.go
+++ b/cmd/crawlergo/flag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/Qianlitp/crawlergo/pkg/config"
 	"github.com/urfave/cli/v2"
 )
@@ -33,6 +34,7 @@ var cliFlags = []cli.Flag{
 	SetPushPoolMax(),
 	SetLogLevel(),
 	SetNoHeadless(),
+	SetMaxTime(),
 }
 
 func SetChromePath() *cli.PathFlag {
@@ -145,12 +147,12 @@ func SetRequestProxy() *cli.StringFlag {
 	}
 }
 
-// return &cli.BoolFlag{
-//	Name:        "bypass",
-//	Value:       false,
-//	Usage:       "whether to encode url with detected charset.",
-//	Destination: &taskConfig.EncodeURLWithCharset,
-//},
+//	return &cli.BoolFlag{
+//		Name:        "bypass",
+//		Value:       false,
+//		Usage:       "whether to encode url with detected charset.",
+//		Destination: &taskConfig.EncodeURLWithCharset,
+//	},
 func SetEncodeURL() *cli.BoolFlag {
 	return &cli.BoolFlag{
 		Name:        "encode-url",
@@ -268,5 +270,14 @@ func SetNoHeadless() *cli.BoolFlag {
 		Value:       false,
 		Usage:       "no headless mode",
 		Destination: &taskConfig.NoHeadless,
+	}
+}
+
+func SetMaxTime() *cli.Int64Flag {
+	return &cli.Int64Flag{
+		Name:        "max-run-time",
+		Usage:       "the `Timeout` of the task.",
+		Value:       config.MaxRunTime,
+		Destination: &taskConfig.MaxRunTime,
 	}
 }

--- a/cmd/crawlergo/main.go
+++ b/cmd/crawlergo/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/Qianlitp/crawlergo/pkg"
 	"github.com/Qianlitp/crawlergo/pkg/config"
@@ -152,8 +153,8 @@ func run(c *cli.Context) error {
 		os.Exit(-1)
 	}
 	if len(targets) != 0 {
-		logger.Logger.Info(fmt.Sprintf("Init crawler task, host: %s, max tab count: %d, max crawl count: %d.",
-			targets[0].URL.Host, taskConfig.MaxTabsCount, taskConfig.MaxCrawlCount))
+		logger.Logger.Infof("Init crawler task, host: %s, max tab count: %d, max crawl count: %d, max runtime: %ds",
+			targets[0].URL.Host, taskConfig.MaxTabsCount, taskConfig.MaxCrawlCount, taskConfig.MaxRunTime)
 		logger.Logger.Info("filter mode: ", taskConfig.FilterMode)
 	}
 
@@ -175,8 +176,8 @@ func run(c *cli.Context) error {
 	task.Run()
 	result := task.Result
 
-	logger.Logger.Info(fmt.Sprintf("Task finished, %d results, %d requests, %d subdomains, %d domains found.",
-		len(result.ReqList), len(result.AllReqList), len(result.SubDomainList), len(result.AllDomainList)))
+	logger.Logger.Infof("Task finished, %d results, %d requests, %d subdomains, %d domains found, runtime: %d",
+		len(result.ReqList), len(result.AllReqList), len(result.SubDomainList), len(result.AllDomainList), time.Now().Unix()-task.Start.Unix())
 
 	// 内置请求代理
 	if pushAddress != "" {
@@ -254,7 +255,8 @@ func outputResult(result *pkg.Result) {
 	}
 }
 
-/**
+/*
+*
 原生被动代理推送支持
 */
 func Push2Proxy(reqList []*model2.Request) {
@@ -277,7 +279,8 @@ func Push2Proxy(reqList []*model2.Request) {
 	pushProxyWG.Wait()
 }
 
-/**
+/*
+*
 协程池请求的任务
 */
 func (p *ProxyTask) doRequest() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ const (
 	BeforeExitDelay         = 1 * time.Second
 	DefaultEventTriggerMode = EventTriggerAsync
 	MaxCrawlCount           = 200
+	MaxRunTime              = 60 * 60
 )
 
 // 请求方法

--- a/pkg/taskconfig.go
+++ b/pkg/taskconfig.go
@@ -25,6 +25,7 @@ type TaskConfig struct {
 	Proxy                   string            // 请求代理
 	CustomFormValues        map[string]string // 自定义表单填充参数
 	CustomFormKeywordValues map[string]string // 自定义表单关键词填充内容
+	MaxRunTime              int64             // 最大爬取时间(单位秒），超时则结束任务，平滑结束（比如某个url还未处理完不能结束，需要一次req完成后才可以结束整个任务）
 }
 
 type TaskConfigOptFunc func(*TaskConfig)


### PR DESCRIPTION
目前没有整个进程的最大运行时间控制，因此实现此功能；
但无法达到精准的控制，只能在秒级别内，比如设置20秒，会在20-23秒左右停止

## 配置: 
1. 增加配置项：max-run-time 单位秒:  `./crawlergo --max-run-time=20 www.xxx.com`
2. config.go: `MaxRunTime` 默认最大执行时间为 3600秒

## 控制点
1.  产生新url 阶段- `task_main.go:addTask2Pool()`： 若检测超时则无法再添加新的url 创建新的tab
2.  创建tab准备爬取 阶段- `task_main.go:Task()`： 
```go
	// 设置tab超时时间，若设置了程序最大运行时间， tab超时时间和程序剩余时间取小
	timeremaining := t.crawlerTask.Start.Add(time.Duration(t.crawlerTask.Config.MaxRunTime) * time.Second).Sub(time.Now())
	tabTime := t.crawlerTask.Config.TabRunTimeout
	if t.crawlerTask.Config.TabRunTimeout > timeremaining {
		tabTime = timeremaining
	}

	if tabTime <= 0 {
		return
	}
```
每个tab的最大超时时间由`TabRunTimeout`控制，因此这里的逻辑是：
进程剩余时间和tab最大超时时间 取最小，作为 tab的超时时间。
如果没时间了，则取消创建。

