### PR TITLE
Fix duplicate parameter key concatenation in smart filter

### DIFF
--- a/pkg/filter/smart_filter.go
+++ b/pkg/filter/smart_filter.go
@@ -392,17 +392,17 @@ func MarkPath(path string) string {
 全局数值型参数过滤
 */
 func (s *SmartFilter) globalFilterLocationMark(req *model.Request) {
-	name := req.URL.Hostname() + req.URL.Path + req.Method
+	base := req.URL.Hostname() + req.URL.Path + req.Method
 	if req.Method == config.GET || req.Method == config.DELETE || req.Method == config.HEAD || req.Method == config.OPTIONS {
 		for key := range req.Filter.MarkedQueryMap {
-			name += key
+			name := base + key
 			if s.filterLocationSet.Contains(name) {
 				req.Filter.MarkedQueryMap[key] = CustomValueMark
 			}
 		}
 	} else if req.Method == config.POST || req.Method == config.PUT {
 		for key := range req.Filter.MarkedPostDataMap {
-			name += key
+			name := base + key
 			if s.filterLocationSet.Contains(name) {
 				req.Filter.MarkedPostDataMap[key] = CustomValueMark
 			}


### PR DESCRIPTION
https://github.com/Qianlitp/crawlergo/blob/c47db8c53730d4db1b7a5ef6b622a97eb4e9ff37/pkg/filter/smart_filter.go#L285-L287

Based on above code, I think the `name` for `filterLocationSet` should be one key at a time, instead of concatenating them all together.